### PR TITLE
feat #90: 탈퇴 회원수 대시보드 추가

### DIFF
--- a/src/main/java/com/example/portpilot/adminPage/dashboard/DashboardController.java
+++ b/src/main/java/com/example/portpilot/adminPage/dashboard/DashboardController.java
@@ -26,4 +26,14 @@ public class DashboardController {
     ) {
         return dashboardService.getSignupStats(start, end);
     }
+
+
+    @GetMapping("/withdraw-stats")
+    public List<WithdrawStatDto> getWithdrawStats(
+            @RequestParam("start") @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate start,
+            @RequestParam("end") @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate end
+    ) {
+        return dashboardService.getWithdrawStats(start, end);
+    }
+
 }

--- a/src/main/java/com/example/portpilot/adminPage/dashboard/DashboardService.java
+++ b/src/main/java/com/example/portpilot/adminPage/dashboard/DashboardService.java
@@ -19,4 +19,9 @@ public class DashboardService {
     public List<SignupStatDto> getSignupStats(LocalDate start, LocalDate end) {
         return userRepository.countNewUsersByDate(start.atStartOfDay(), end.plusDays(1).atStartOfDay());
     }
+
+    public List<WithdrawStatDto> getWithdrawStats(LocalDate start, LocalDate end) {
+        return userRepository.countWithdrawnUsersByDate(start.atStartOfDay(), end.plusDays(1).atStartOfDay());
+    }
+
 }

--- a/src/main/java/com/example/portpilot/adminPage/dashboard/WithdrawStatDto.java
+++ b/src/main/java/com/example/portpilot/adminPage/dashboard/WithdrawStatDto.java
@@ -1,0 +1,18 @@
+package com.example.portpilot.adminPage.dashboard;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.Date;
+
+@Getter
+@NoArgsConstructor
+public class WithdrawStatDto {
+    private Date date;
+    private Long count;
+
+    public WithdrawStatDto(Date date, Long count) {
+        this.date = date;
+        this.count = count;
+    }
+}

--- a/src/main/java/com/example/portpilot/domain/user/User.java
+++ b/src/main/java/com/example/portpilot/domain/user/User.java
@@ -7,6 +7,7 @@ import lombok.ToString;
 import org.springframework.security.crypto.password.PasswordEncoder;
 
 import javax.persistence.*;
+import java.time.LocalDateTime;
 
 @Entity
 @Table(name="t_user")
@@ -28,6 +29,18 @@ public class User extends BaseEntity {
 
     private Role role;
 
+    @Column(nullable = false)
+    private boolean isDeleted = false;
+
+    private LocalDateTime deletedAt;
+
+    @Column(nullable = false)
+    private boolean isBlocked = false;
+
+    private LocalDateTime blockedAt;
+
+    private LocalDateTime blockedUntil;
+
     // User 엔터티 생성 메소드.
     public static User createUser(UserFormDto userFormDto, PasswordEncoder passwordEncoder){
         User user = new User();
@@ -39,4 +52,25 @@ public class User extends BaseEntity {
         user.setRole(Role.USER);
         return user;
     }
+
+    // 탈퇴 처리
+    public void withdraw() {
+        this.isDeleted = true;
+        this.deletedAt = LocalDateTime.now();
+    }
+
+    // 차단 처리
+    public void blockUntil(LocalDateTime until) {
+        this.isBlocked = true;
+        this.blockedAt = LocalDateTime.now();
+        this.blockedUntil = until;
+    }
+
+    // 차단 해제
+    public void unblock() {
+        this.isBlocked = false;
+        this.blockedAt = null;
+        this.blockedUntil = null;
+    }
+
 }

--- a/src/main/java/com/example/portpilot/domain/user/UserRepository.java
+++ b/src/main/java/com/example/portpilot/domain/user/UserRepository.java
@@ -1,6 +1,7 @@
 package com.example.portpilot.domain.user;
 
 import com.example.portpilot.adminPage.dashboard.SignupStatDto;
+import com.example.portpilot.adminPage.dashboard.WithdrawStatDto;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -17,5 +18,11 @@ public interface UserRepository extends JpaRepository<User, Long> {
     List<SignupStatDto> countNewUsersByDate(@Param("start") LocalDateTime start,
                                             @Param("end") LocalDateTime end);
 
+
+    @Query("SELECT new com.example.portpilot.adminPage.dashboard.WithdrawStatDto(FUNCTION('DATE', u.deletedAt), COUNT(u)) " +
+            "FROM User u WHERE u.isDeleted = true AND u.deletedAt BETWEEN :start AND :end " +
+            "GROUP BY FUNCTION('DATE', u.deletedAt) ORDER BY FUNCTION('DATE', u.deletedAt)")
+    List<WithdrawStatDto> countWithdrawnUsersByDate(@Param("start") LocalDateTime start,
+                                                    @Param("end") LocalDateTime end);
 
 }

--- a/src/main/java/com/example/portpilot/global/config/SecurityConfig.java
+++ b/src/main/java/com/example/portpilot/global/config/SecurityConfig.java
@@ -72,6 +72,6 @@ public class SecurityConfig extends WebSecurityConfigurerAdapter {
 
     @Override
     public void configure(WebSecurity web) {
-        web.ignoring().antMatchers("/css/**", "/js/**", "/img/**");
+        web.ignoring().antMatchers("/css/**", "/static/js/**", "/img/**");
     }
 }

--- a/src/main/resources/static/css/admin/main.css
+++ b/src/main/resources/static/css/admin/main.css
@@ -49,3 +49,42 @@
     margin-left: 240px;
     padding: 2rem;
 }
+
+
+/* 날짜 선택 영역 */
+.date-filter {
+    margin-bottom: 1.5rem;
+    display: flex;
+    align-items: center;
+    gap: 1rem;
+    flex-wrap: wrap;
+}
+
+.date-filter label {
+    font-weight: bold;
+    color: #444;
+}
+
+.date-filter input[type="date"] {
+    padding: 6px 10px;
+    border: 1px solid #ccc;
+    border-radius: 6px;
+    font-size: 14px;
+    background-color: #fff;
+    color: #333;
+}
+
+.date-filter button {
+    padding: 6px 14px;
+    font-size: 14px;
+    background-color: #4e73df;
+    color: white;
+    border: none;
+    border-radius: 6px;
+    cursor: pointer;
+    transition: background-color 0.2s ease-in-out;
+}
+
+.date-filter button:hover {
+    background-color: #375ac2;
+}

--- a/src/main/resources/static/js/admin/main.js
+++ b/src/main/resources/static/js/admin/main.js
@@ -1,0 +1,75 @@
+document.addEventListener("DOMContentLoaded", function () {
+    const newUserCtx = document.getElementById('newUserChart').getContext('2d');
+    const leftUserCtx = document.getElementById('leftUserChart').getContext('2d');
+
+    let newUserChart, leftUserChart;
+
+    function drawChart(ctx, data, label, color, backgroundColor, chartRef) {
+        if (chartRef.chart) {
+            chartRef.chart.destroy();
+        }
+
+        chartRef.chart = new Chart(ctx, {
+            type: 'line',
+            data: {
+                labels: data.map(d => d.date),
+                datasets: [{
+                    label: label,
+                    data: data.map(d => d.count),
+                    borderColor: color,
+                    backgroundColor: backgroundColor,
+                    fill: true,
+                    tension: 0.3
+                }]
+            },
+            options: {
+                responsive: true,
+                plugins: {
+                    legend: { display: true },
+                    tooltip: { mode: 'index', intersect: false }
+                },
+                scales: {
+                    x: { title: { display: true, text: '날짜' }},
+                    y: {
+                        beginAtZero: true,
+                        title: { display: true, text: label },
+                        ticks: { precision: 0 }
+                    }
+                }
+            }
+        });
+    }
+
+    function fetchAndRender(start, end) {
+        const newUserRef = { chart: newUserChart, set chart(val) { newUserChart = val; }, get chart() { return newUserChart; } };
+        const leftUserRef = { chart: leftUserChart, set chart(val) { leftUserChart = val; }, get chart() { return leftUserChart; } };
+
+        fetch(`/admin/api/dashboard/signup-stats?start=${start}&end=${end}`)
+            .then(res => res.json())
+            .then(data => drawChart(newUserCtx, data, '일별 신규 가입자 수', '#4e73df', 'rgba(78, 115, 223, 0.1)', newUserRef));
+
+        fetch(`/admin/api/dashboard/withdraw-stats?start=${start}&end=${end}`)
+            .then(res => res.json())
+            .then(data => drawChart(leftUserCtx, data, '일별 탈퇴자 수', '#e74a3b', 'rgba(231, 74, 59, 0.1)', leftUserRef));
+    }
+
+    // 초기 설정 (최근 7일)
+    const today = new Date();
+    const start = new Date();
+    start.setDate(today.getDate() - 6);
+
+    const formatDate = (d) => d.toISOString().split('T')[0];
+    document.getElementById('startDate').value = formatDate(start);
+    document.getElementById('endDate').value = formatDate(today);
+
+    fetchAndRender(formatDate(start), formatDate(today));
+
+    // 조회 버튼 이벤트
+    document.getElementById('loadStatsBtn').addEventListener('click', () => {
+        const startDate = document.getElementById('startDate').value;
+        const endDate = document.getElementById('endDate').value;
+        if (startDate && endDate) {
+            fetchAndRender(startDate, endDate);
+        }
+    });
+});

--- a/src/main/resources/templates/admin/adminMain.html
+++ b/src/main/resources/templates/admin/adminMain.html
@@ -3,10 +3,9 @@
       xmlns:layout="http://www.ultraq.net.nz/thymeleaf/layout"
       layout:decorate="~{admin/layouts/layout}">
 
-<!-- 올바른 HTML 구조로 작성 -->
-
 <head>
     <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
+    <script th:src="@{/js/admin/main.js}" defer></script>
 </head>
 
 <body>
@@ -14,6 +13,19 @@
     <div class="main">
         <div class="dashboard-header">대시보드</div>
 
+        <!-- 날짜 선택 영역 -->
+        <div class="date-filter">
+            <label for="startDate">시작일</label>
+            <input type="date" id="startDate" name="startDate">
+
+            <label for="endDate">종료일</label>
+            <input type="date" id="endDate" name="endDate">
+
+            <button id="loadStatsBtn">조회</button>
+        </div>
+
+
+        <!-- 상단 통계 -->
         <div class="row">
             <div class="col">
                 <div class="card">
@@ -33,6 +45,7 @@
             </div>
         </div>
 
+        <!-- 하단 통계 -->
         <div class="row" style="margin-top:2rem;">
             <div class="col">
                 <div class="card">
@@ -51,57 +64,6 @@
             </div>
         </div>
     </div>
-
-    <!-- JS 코드 -->
-    <script>
-        document.addEventListener("DOMContentLoaded", function () {
-            const ctx = document.getElementById('newUserChart').getContext('2d');
-
-            const today = new Date();
-            const start = new Date();
-            start.setDate(today.getDate() - 6);
-
-            const formatDate = (d) => d.toISOString().split('T')[0];
-
-            fetch(`/admin/api/dashboard/signup-stats?start=${formatDate(start)}&end=${formatDate(today)}`)
-                .then(res => res.json())
-                .then(data => {
-                    const labels = data.map(item => item.date);
-                    const counts = data.map(item => item.count);
-
-                    new Chart(ctx, {
-                        type: 'line',
-                        data: {
-                            labels: labels,
-                            datasets: [{
-                                label: '일별 신규 가입자 수',
-                                data: counts,
-                                borderColor: '#4e73df',
-                                backgroundColor: 'rgba(78, 115, 223, 0.1)',
-                                fill: true,
-                                tension: 0.3
-                            }]
-                        },
-                        options: {
-                            responsive: true,
-                            plugins: {
-                                legend: { display: true },
-                                tooltip: { mode: 'index', intersect: false }
-                            },
-                            scales: {
-                                x: { title: { display: true, text: '날짜' }},
-                                y: { beginAtZero: true,
-                                    title: { display: true, text: '가입자 수' },
-                                    ticks: {
-                                        precision: 0
-                                    }
-                                }
-                            }
-                        }
-                    });
-                });
-        });
-    </script>
 </div>
 </body>
 


### PR DESCRIPTION
## 📌 Summary
- #16 

<br>

## ✨ Description
- 사용자가 검색 날짜 범위 지정 가능하도록 인풋추가
- 탈퇴 회원수 대시보드 추가
- user 엔티티에 block관련 컬럼과 delete 관련 컬럼추가
`
    @Column(nullable = false)
    private boolean isDeleted = false;

    private LocalDateTime deletedAt;

    @Column(nullable = false)
    private boolean isBlocked = false;

    private LocalDateTime blockedAt;

    private LocalDateTime blockedUntil;
`

<br>

## 📸 Screenshot
<img width="1914" height="953" alt="image" src="https://github.com/user-attachments/assets/68eb0e47-851a-4a72-8ace-399890a7d18e" />

