### PR TITLE
refactor #156: 로그인 오류 수정

### DIFF
--- a/src/main/java/com/example/portpilot/global/config/CustomAuthenticationFilter.java
+++ b/src/main/java/com/example/portpilot/global/config/CustomAuthenticationFilter.java
@@ -1,0 +1,38 @@
+package com.example.portpilot.global.config;
+
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+public class CustomAuthenticationFilter extends UsernamePasswordAuthenticationFilter {
+
+    private final AuthenticationManager userAuthManager;
+    private final AuthenticationManager adminAuthManager;
+
+    public CustomAuthenticationFilter(AuthenticationManager userAuthManager,
+                                      AuthenticationManager adminAuthManager) {
+        super(userAuthManager);
+        this.userAuthManager = userAuthManager;
+        this.adminAuthManager = adminAuthManager;
+        setFilterProcessesUrl("/login");
+    }
+
+    @Override
+    public Authentication attemptAuthentication(HttpServletRequest request, HttpServletResponse response)
+            throws AuthenticationException {
+
+        String uri = request.getRequestURI();
+
+        if (uri.startsWith("/admin")) {
+            super.setAuthenticationManager(adminAuthManager);
+        } else {
+            super.setAuthenticationManager(userAuthManager);
+        }
+
+        return super.attemptAuthentication(request, response);
+    }
+}

--- a/src/main/java/com/example/portpilot/global/config/PasswordEncoderConfig.java
+++ b/src/main/java/com/example/portpilot/global/config/PasswordEncoderConfig.java
@@ -1,0 +1,15 @@
+package com.example.portpilot.global.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
+
+@Configuration
+public class PasswordEncoderConfig {
+
+    @Bean
+    public PasswordEncoder passwordEncoder() {
+        return new BCryptPasswordEncoder();
+    }
+}

--- a/src/main/resources/templates/fragments/header.html
+++ b/src/main/resources/templates/fragments/header.html
@@ -16,9 +16,11 @@
                 <li class="nav-item" sec:authorize="isAnonymous()">
                     <a class="nav-link" href="/users/login">로그인</a>
                 </li>
-                <li class="nav-item" sec:authorize="isAuthenticated()">
-                    <a class="nav-link" href="/users/logout">로그아웃</a>
-                </li>
+                <form th:action="@{/users/logout}" method="post">
+                    <input type="hidden" th:name="${_csrf.parameterName}" th:value="${_csrf.token}" />
+                    <button type="submit" class="btn btn-link nav-link" style="padding: 0;">로그아웃</button>
+                </form>
+
             </ul>
             <form class="form-inline my-2 my-lg-0" th:action="@{/}" method="get">
                 <input name="searchQuery" class="form-control mr-sm-2 bg-dark text-white border-light" type="search" placeholder="Search" aria-label="Search">


### PR DESCRIPTION
## 📌 Summary
로그인 안되는 이슈 수정

<br>

## ✨ Description
**기존 코드 문제점**
Spring Security는 내부적으로 AuthenticationManagerBuilder에 설정된 마지막 UserDetailsService만 유효하게 등록합니다.
즉, 아래 코드에서는 adminService만 등록되고 userService는 무시된 상태가 됩니다.
```
@Override
public void configure(AuthenticationManagerBuilder auth) throws Exception {
    auth.userDetailsService(userService).passwordEncoder(passwordEncoder());
    auth.userDetailsService(adminService).passwordEncoder(passwordEncoder());
}

```
현재는 WebSecurityConfigurerAdapter를 사용하지 않고, 각각의 인증 매니저와 필터를 분리 등록했기 때문에 동작이 명확해졌습니다.

/users/** 요청은 userAuthManager()를 타고 userService를 사용

/admin/** 요청은 adminAuthManager()를 타고 adminService를 사용

따라서 경로에 따라 인증 주체(UserDetailsService)를 분기하는 구조로 정확히 작동함


