### PR TITLE
Feature #34: 자소서 목록 페이지

### DIFF
--- a/src/main/java/com/example/portpilot/domain/resume/service/ResumeService.java
+++ b/src/main/java/com/example/portpilot/domain/resume/service/ResumeService.java
@@ -43,8 +43,13 @@ public class ResumeService {
     private final UserRepository userRepository;
 
     // 목록 조회
+    @Transactional(readOnly = true)
     public List<ResumeResponse> getResumeList(Long userId) {
         List<Resume> resumes = resumeRepository.findByUserIdOrderByUpdatedAtDesc(userId);
+
+        // 각 resume의 lazy collection 초기화
+        resumes.forEach(this::initializeLazyCollections);
+
         return resumes.stream()
                 .map(ResumeResponse::new)
                 .collect(Collectors.toList());

--- a/src/main/java/com/example/portpilot/domain/resume/service/ResumeService.java
+++ b/src/main/java/com/example/portpilot/domain/resume/service/ResumeService.java
@@ -135,6 +135,8 @@ public class ResumeService {
             resume.updateStatus(request.getStatus());
         }
 
+        initializeLazyCollections(resume);
+
         return new ResumeResponse(resume);
     }
 

--- a/src/main/java/com/example/portpilot/domain/resume/service/ResumeService.java
+++ b/src/main/java/com/example/portpilot/domain/resume/service/ResumeService.java
@@ -123,14 +123,20 @@ public class ResumeService {
         Resume resume = resumeRepository.findByIdAndUserId(resumeId, userId)
                 .orElseThrow(() -> new RuntimeException("이력서를 찾을 수 없습니다."));
 
-        resume.updateBasicInfo(
-                request.getTitle(),
-                request.getIndustry(),
-                request.getPosition(),
-                request.getTargetCompany(),
-                request.getHighlights()
-        );
+        if (request.getTitle() != null || request.getIndustry() != null ||
+                request.getPosition() != null || request.getTargetCompany() != null ||
+                request.getHighlights() != null) {
 
+            resume.updateBasicInfo(
+                    request.getTitle() != null ? request.getTitle() : resume.getTitle(),
+                    request.getIndustry() != null ? request.getIndustry() : resume.getIndustry(),
+                    request.getPosition() != null ? request.getPosition() : resume.getPosition(),
+                    request.getTargetCompany() != null ? request.getTargetCompany() : resume.getTargetCompany(),
+                    request.getHighlights() != null ? request.getHighlights() : resume.getHighlights()
+            );
+        }
+
+        // 상태만 변경하는 요청인 경우 처리
         if (request.getStatus() != null) {
             resume.updateStatus(request.getStatus());
         }

--- a/src/main/resources/templates/resume/resume-info.html
+++ b/src/main/resources/templates/resume/resume-info.html
@@ -474,7 +474,7 @@
     experiences: []
   };
 
-  let resumeCounter = 1;
+  let resumeCounter = 1; // 기본값, 실제로는 서버에서 조회해서 설정
 
   // 업종별 직무 매핑
   const industryToPositionMapping = {
@@ -512,6 +512,31 @@
     return urlParams.get('resumeId');
   }
 
+  // 기존 이력서 개수 조회하여 다음 번호 설정
+  async function loadResumeCount() {
+    try {
+      const response = await fetch('/api/resumes', {
+        method: 'GET',
+        headers: getCSRFHeaders()
+      });
+
+      if (response.ok) {
+        const resumes = await response.json();
+        // 기존 이력서 개수 + 1로 설정
+        resumeCounter = resumes.length + 1;
+        console.log(`기존 이력서 ${resumes.length}개, 다음 번호: ${resumeCounter}`);
+      } else {
+        // API 호출 실패 시 기본값 1 사용
+        console.warn('이력서 목록 조회 실패, 기본 번호 사용');
+        resumeCounter = 1;
+      }
+    } catch (error) {
+      console.error('이력서 개수 조회 중 오류:', error);
+      // 오류 발생 시 기본값 1 사용
+      resumeCounter = 1;
+    }
+  }
+
   // 페이지 초기화
   async function init() {
     setupYearOptions();
@@ -535,6 +560,9 @@
     } else {
       // 새 작성 모드
       isEditMode = false;
+      // 먼저 기존 이력서 개수를 조회하여 다음 번호 설정
+      await loadResumeCount();
+      // 그 다음 제목 설정
       setDefaultTitle();
       hideLoading();
     }

--- a/src/main/resources/templates/resume/resume-info.html
+++ b/src/main/resources/templates/resume/resume-info.html
@@ -5,7 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <meta name="_csrf" th:content="${_csrf.token}"/>
   <meta name="_csrf_header" th:content="${_csrf.headerName}"/>
-  <title>이력서 작성</title>
+  <title id="pageTitle">이력서 작성</title>
   <style>
     * {
       margin: 0;
@@ -269,6 +269,27 @@
       margin: 0;
     }
 
+    .loading {
+      display: none;
+      text-align: center;
+      padding: 4rem;
+      color: #6b7280;
+    }
+
+    .spinner {
+      width: 24px;
+      height: 24px;
+      border: 3px solid #e5e7eb;
+      border-radius: 50%;
+      border-top-color: #3b82f6;
+      animation: spin 1s ease-in-out infinite;
+      margin: 0 auto 1rem;
+    }
+
+    @keyframes spin {
+      to { transform: rotate(360deg); }
+    }
+
     @media (max-width: 768px) {
       .container {
         flex-direction: column;
@@ -294,12 +315,18 @@
 <body>
 <div class="header">
   <div class="header-content">
-    <h1>이력서 작성</h1>
-    <p>나만의 특별한 이력서로 원하는 취업에 도전하세요.</p>
+    <h1 id="headerTitle">이력서 작성</h1>
+    <p id="headerDescription">나만의 특별한 이력서로 원하는 취업에 도전하세요.</p>
   </div>
 </div>
 
-<div class="container">
+<!-- 로딩 상태 -->
+<div id="loadingState" class="loading">
+  <div class="spinner"></div>
+  <p>이력서 정보를 불러오는 중...</p>
+</div>
+
+<div class="container" id="mainContainer" style="display: none;">
   <div class="main-content">
     <!-- 제목 섹션 -->
     <section id="basic" class="section">
@@ -425,13 +452,15 @@
         </nav>
       </div>
 
-      <button class="submit-btn" onclick="handleSubmit()" disabled>AI 이력서 생성</button>
+      <button class="submit-btn" onclick="handleSubmit()" id="submitBtn">AI 이력서 생성</button>
     </div>
   </div>
 </div>
 
 <script>
-  // 데이터 구조
+  // 전역 변수
+  let isEditMode = false;
+  let currentResumeId = null;
   let formData = {
     title: '',
     industry: '',
@@ -445,7 +474,7 @@
     experiences: []
   };
 
-  let resumeCounter = 1; // 이력서 자동 번호
+  let resumeCounter = 1;
 
   // 업종별 직무 매핑
   const industryToPositionMapping = {
@@ -461,7 +490,7 @@
     '기타': ['경영기획', '사업기획', '총무', '인사', '마케팅기획', '영업', '기타']
   };
 
-  // CSRF 토큰 가져오기 함수
+  // CSRF 토큰 가져오기
   function getCSRFHeaders() {
     const token = document.querySelector('meta[name="_csrf"]')?.getAttribute('content');
     const header = document.querySelector('meta[name="_csrf_header"]')?.getAttribute('content');
@@ -477,12 +506,247 @@
     return headers;
   }
 
-  // 초기화
-  function init() {
+  // URL에서 resumeId 파라미터 추출
+  function getResumeIdFromUrl() {
+    const urlParams = new URLSearchParams(window.location.search);
+    return urlParams.get('resumeId');
+  }
+
+  // 페이지 초기화
+  async function init() {
     setupYearOptions();
+
+    // URL에서 resumeId 확인
+    const resumeId = getResumeIdFromUrl();
+
+    if (resumeId) {
+      // 편집 모드
+      isEditMode = true;
+      currentResumeId = resumeId;
+
+      // UI 변경
+      document.getElementById('pageTitle').textContent = '이력서 수정';
+      document.getElementById('headerTitle').textContent = '이력서 수정';
+      document.getElementById('headerDescription').textContent = '기존 이력서 정보를 수정하세요.';
+      document.getElementById('submitBtn').textContent = 'AI 이력서 수정';
+
+      // 기존 데이터 로드
+      await loadExistingData(resumeId);
+    } else {
+      // 새 작성 모드
+      isEditMode = false;
+      setDefaultTitle();
+      hideLoading();
+    }
+
     setupEventListeners();
-    setDefaultTitle();
-    // 기본으로 하나씩 추가하지 않음 - 사용자가 필요시에만 추가
+  }
+
+  // 기존 데이터 로드
+  async function loadExistingData(resumeId) {
+    try {
+      showLoading();
+
+      const response = await fetch(`/api/resumes/${resumeId}`, {
+        method: 'GET',
+        headers: getCSRFHeaders()
+      });
+
+      if (response.ok) {
+        const resumeData = await response.json();
+        populateFormWithData(resumeData);
+        hideLoading();
+      } else {
+        throw new Error('이력서 데이터를 불러올 수 없습니다.');
+      }
+    } catch (error) {
+      console.error('Load error:', error);
+      alert('이력서 데이터를 불러오는 중 오류가 발생했습니다: ' + error.message);
+      // 목록으로 돌아가기
+      window.location.href = '/resumes';
+    }
+  }
+
+  // 폼에 기존 데이터 채우기
+  function populateFormWithData(resumeData) {
+    // 기본 정보
+    document.getElementById('title').value = resumeData.title || '';
+    document.getElementById('target-company').value = resumeData.targetCompany || '';
+    document.getElementById('highlights-text').value = resumeData.highlights || '';
+
+    // 업종/직무
+    if (resumeData.industry) {
+      document.getElementById('industry').value = resumeData.industry;
+      updatePositionOptions();
+      if (resumeData.position) {
+        document.getElementById('position').value = resumeData.position;
+      }
+    }
+
+    // formData 업데이트
+    formData.title = resumeData.title || '';
+    formData.industry = resumeData.industry || '';
+    formData.position = resumeData.position || '';
+    formData.targetCompany = resumeData.targetCompany || '';
+    formData.highlights = resumeData.highlights || '';
+
+    // 학력 정보 (고등학교)
+    if (resumeData.educations) {
+      const highSchool = resumeData.educations.find(edu => edu.type === 'HIGH_SCHOOL');
+      if (highSchool) {
+        document.getElementById('highschool-name').value = highSchool.schoolName || '';
+        if (highSchool.graduationDate) {
+          const gradYear = new Date(highSchool.graduationDate).getFullYear();
+          document.getElementById('highschool-year').value = gradYear;
+        }
+        formData.highschool.schoolName = highSchool.schoolName || '';
+        formData.highschool.graduationYear = document.getElementById('highschool-year').value;
+      }
+
+      // 대학교
+      const universities = resumeData.educations.filter(edu => edu.type === 'UNIVERSITY');
+      universities.forEach(university => {
+        addUniversity();
+        const index = formData.universities.length - 1;
+        formData.universities[index] = {
+          schoolName: university.schoolName || '',
+          type: university.level || '',
+          major: university.major || '',
+          additionalMajor: university.additionalMajor || '',
+          admissionDate: university.admissionDate || '',
+          graduationDate: university.graduationDate || '',
+          isCurrent: university.isCurrent || false
+        };
+        updateUniversityDisplay(index);
+      });
+
+      // 대학원
+      const graduateSchools = resumeData.educations.filter(edu => edu.type === 'GRADUATE_SCHOOL');
+      graduateSchools.forEach(graduate => {
+        addGraduateSchool();
+        const index = formData.graduateSchools.length - 1;
+        formData.graduateSchools[index] = {
+          schoolName: graduate.schoolName || '',
+          type: graduate.level || '',
+          major: graduate.major || '',
+          admissionDate: graduate.admissionDate || '',
+          graduationDate: graduate.graduationDate || '',
+          isCurrent: graduate.isCurrent || false
+        };
+        updateGraduateSchoolDisplay(index);
+      });
+    }
+
+    // 경력 정보
+    if (resumeData.careers) {
+      resumeData.careers.forEach(career => {
+        addCareer();
+        const index = formData.careers.length - 1;
+        formData.careers[index] = {
+          companyName: career.companyName || '',
+          department: career.department || '',
+          positionTitle: career.positionTitle || '',
+          startDate: career.startDate || '',
+          endDate: career.endDate || '',
+          isCurrent: career.isCurrent || false,
+          responsibilities: career.responsibilities || '',
+          resignationReason: career.resignationReason || ''
+        };
+        updateCareerDisplay(index);
+      });
+    }
+
+    // 활동/경험
+    if (resumeData.experiences) {
+      resumeData.experiences.forEach(experience => {
+        addExperience();
+        const index = formData.experiences.length - 1;
+        formData.experiences[index] = {
+          activityName: experience.activityName || '',
+          institution: experience.institution || '',
+          startDate: experience.startDate || '',
+          endDate: experience.endDate || '',
+          isCurrent: experience.isCurrent || false,
+          content: experience.content || ''
+        };
+        updateExperienceDisplay(index);
+      });
+    }
+  }
+
+  // 표시 업데이트 함수들
+  function updateUniversityDisplay(index) {
+    const container = document.getElementById('universities');
+    const universityDiv = container.children[index];
+    const data = formData.universities[index];
+
+    universityDiv.querySelector('input[placeholder="대학교명"]').value = data.schoolName;
+    universityDiv.querySelector('select').value = data.type;
+    const inputs = universityDiv.querySelectorAll('input');
+    inputs[1].value = data.admissionDate; // 입학일
+    inputs[2].value = data.graduationDate; // 졸업일
+    inputs[3].value = data.major; // 전공
+    inputs[4].value = data.additionalMajor; // 추가전공
+    universityDiv.querySelector('input[type="checkbox"]').checked = data.isCurrent;
+  }
+
+  function updateGraduateSchoolDisplay(index) {
+    const container = document.getElementById('graduate-schools');
+    const graduateDiv = container.children[index];
+    const data = formData.graduateSchools[index];
+
+    graduateDiv.querySelector('input[placeholder="대학원명"]').value = data.schoolName;
+    graduateDiv.querySelector('select').value = data.type;
+    const inputs = graduateDiv.querySelectorAll('input');
+    inputs[1].value = data.admissionDate; // 입학일
+    inputs[2].value = data.graduationDate; // 졸업일
+    inputs[3].value = data.major; // 전공
+    graduateDiv.querySelector('input[type="checkbox"]').checked = data.isCurrent;
+  }
+
+  function updateCareerDisplay(index) {
+    const container = document.getElementById('careers');
+    const careerDiv = container.children[index];
+    const data = formData.careers[index];
+
+    const inputs = careerDiv.querySelectorAll('input');
+    const textareas = careerDiv.querySelectorAll('textarea');
+
+    inputs[0].value = data.companyName; // 회사명
+    inputs[1].value = data.department; // 부서
+    inputs[2].value = data.startDate; // 입사일
+    inputs[3].value = data.endDate; // 퇴사일
+    inputs[4].value = data.positionTitle; // 직급
+    careerDiv.querySelector('input[type="checkbox"]').checked = data.isCurrent;
+    textareas[0].value = data.responsibilities; // 담당업무
+    inputs[5].value = data.resignationReason; // 퇴사사유
+  }
+
+  function updateExperienceDisplay(index) {
+    const container = document.getElementById('experiences');
+    const experienceDiv = container.children[index];
+    const data = formData.experiences[index];
+
+    const inputs = experienceDiv.querySelectorAll('input');
+    const textarea = experienceDiv.querySelector('textarea');
+
+    inputs[0].value = data.activityName; // 활동명
+    inputs[1].value = data.institution; // 기관/장소
+    inputs[2].value = data.startDate; // 시작일
+    inputs[3].value = data.endDate; // 종료일
+    experienceDiv.querySelector('input[type="checkbox"]').checked = data.isCurrent;
+    textarea.value = data.content; // 내용
+  }
+
+  // 로딩 상태 표시/숨김
+  function showLoading() {
+    document.getElementById('loadingState').style.display = 'block';
+    document.getElementById('mainContainer').style.display = 'none';
+  }
+
+  function hideLoading() {
+    document.getElementById('loadingState').style.display = 'none';
+    document.getElementById('mainContainer').style.display = 'flex';
   }
 
   // 기본 제목 설정
@@ -599,51 +863,51 @@
     const universityDiv = document.createElement('div');
     universityDiv.className = 'dynamic-item';
     universityDiv.innerHTML = `
-                <button type="button" class="remove-btn" onclick="removeUniversity(${index})">×</button>
-                <div class="form-content">
-                    <div class="form-row">
-                        <div class="form-group">
-                            <label>학교명</label>
-                            <input type="text" placeholder="대학교명" onchange="updateUniversity(${index}, 'schoolName', this.value)">
-                        </div>
-                        <div class="form-group">
-                            <label>분류</label>
-                            <select onchange="updateUniversity(${index}, 'type', this.value)">
-                                <option value="">선택</option>
-                                <option value="2년제">2년제</option>
-                                <option value="3년제">3년제</option>
-                                <option value="4년제">4년제</option>
-                            </select>
-                        </div>
-                    </div>
-                    <div class="form-row">
-                        <div class="form-group">
-                            <label>입학</label>
-                            <input type="month" data-field="admission" onchange="updateUniversity(${index}, 'admissionDate', this.value)">
-                        </div>
-                        <div class="form-group">
-                            <label>졸업</label>
-                            <input type="month" data-field="graduation" onchange="updateUniversity(${index}, 'graduationDate', this.value)">
-                        </div>
-                    </div>
-                    <div class="form-row">
-                        <div class="form-group">
-                            <label>전공</label>
-                            <input type="text" placeholder="전공" onchange="updateUniversity(${index}, 'major', this.value)">
-                        </div>
-                        <div class="form-group">
-                            <label>추가전공</label>
-                            <input type="text" placeholder="부전공, 복수전공 등" onchange="updateUniversity(${index}, 'additionalMajor', this.value)">
-                        </div>
-                    </div>
-                    <div class="form-group">
-                        <label class="checkbox-label">
-                            <input type="checkbox" onchange="updateUniversity(${index}, 'isCurrent', this.checked)">
-                            <span>재학중</span>
-                        </label>
-                    </div>
-                </div>
-            `;
+      <button type="button" class="remove-btn" onclick="removeUniversity(${index})">×</button>
+      <div class="form-content">
+        <div class="form-row">
+          <div class="form-group">
+            <label>학교명</label>
+            <input type="text" placeholder="대학교명" onchange="updateUniversity(${index}, 'schoolName', this.value)">
+          </div>
+          <div class="form-group">
+            <label>분류</label>
+            <select onchange="updateUniversity(${index}, 'type', this.value)">
+              <option value="">선택</option>
+              <option value="2년제">2년제</option>
+              <option value="3년제">3년제</option>
+              <option value="4년제">4년제</option>
+            </select>
+          </div>
+        </div>
+        <div class="form-row">
+          <div class="form-group">
+            <label>입학</label>
+            <input type="month" data-field="admission" onchange="updateUniversity(${index}, 'admissionDate', this.value)">
+          </div>
+          <div class="form-group">
+            <label>졸업</label>
+            <input type="month" data-field="graduation" onchange="updateUniversity(${index}, 'graduationDate', this.value)">
+          </div>
+        </div>
+        <div class="form-row">
+          <div class="form-group">
+            <label>전공</label>
+            <input type="text" placeholder="전공" onchange="updateUniversity(${index}, 'major', this.value)">
+          </div>
+          <div class="form-group">
+            <label>추가전공</label>
+            <input type="text" placeholder="부전공, 복수전공 등" onchange="updateUniversity(${index}, 'additionalMajor', this.value)">
+          </div>
+        </div>
+        <div class="form-group">
+          <label class="checkbox-label">
+            <input type="checkbox" onchange="updateUniversity(${index}, 'isCurrent', this.checked)">
+            <span>재학중</span>
+          </label>
+        </div>
+      </div>
+    `;
 
     container.appendChild(universityDiv);
     formData.universities.push({
@@ -698,45 +962,45 @@
     const graduateDiv = document.createElement('div');
     graduateDiv.className = 'dynamic-item';
     graduateDiv.innerHTML = `
-                <button type="button" class="remove-btn" onclick="removeGraduateSchool(${index})">×</button>
-                <div class="form-content">
-                    <div class="form-row">
-                        <div class="form-group">
-                            <label>학교명</label>
-                            <input type="text" placeholder="대학원명" onchange="updateGraduateSchool(${index}, 'schoolName', this.value)">
-                        </div>
-                        <div class="form-group">
-                            <label>과정</label>
-                            <select onchange="updateGraduateSchool(${index}, 'type', this.value)">
-                                <option value="">선택</option>
-                                <option value="석사">석사</option>
-                                <option value="박사">박사</option>
-                                <option value="석박통합">석박통합</option>
-                            </select>
-                        </div>
-                    </div>
-                    <div class="form-row">
-                        <div class="form-group">
-                            <label>입학</label>
-                            <input type="month" data-field="admission" onchange="updateGraduateSchool(${index}, 'admissionDate', this.value)">
-                        </div>
-                        <div class="form-group">
-                            <label>졸업</label>
-                            <input type="month" data-field="graduation" onchange="updateGraduateSchool(${index}, 'graduationDate', this.value)">
-                        </div>
-                    </div>
-                    <div class="form-group">
-                        <label>전공</label>
-                        <input type="text" placeholder="전공" onchange="updateGraduateSchool(${index}, 'major', this.value)">
-                    </div>
-                    <div class="form-group">
-                        <label class="checkbox-label">
-                            <input type="checkbox" onchange="updateGraduateSchool(${index}, 'isCurrent', this.checked)">
-                            <span>재학중</span>
-                        </label>
-                    </div>
-                </div>
-            `;
+      <button type="button" class="remove-btn" onclick="removeGraduateSchool(${index})">×</button>
+      <div class="form-content">
+        <div class="form-row">
+          <div class="form-group">
+            <label>학교명</label>
+            <input type="text" placeholder="대학원명" onchange="updateGraduateSchool(${index}, 'schoolName', this.value)">
+          </div>
+          <div class="form-group">
+            <label>과정</label>
+            <select onchange="updateGraduateSchool(${index}, 'type', this.value)">
+              <option value="">선택</option>
+              <option value="석사">석사</option>
+              <option value="박사">박사</option>
+              <option value="석박통합">석박통합</option>
+            </select>
+          </div>
+        </div>
+        <div class="form-row">
+          <div class="form-group">
+            <label>입학</label>
+            <input type="month" data-field="admission" onchange="updateGraduateSchool(${index}, 'admissionDate', this.value)">
+          </div>
+          <div class="form-group">
+            <label>졸업</label>
+            <input type="month" data-field="graduation" onchange="updateGraduateSchool(${index}, 'graduationDate', this.value)">
+          </div>
+        </div>
+        <div class="form-group">
+          <label>전공</label>
+          <input type="text" placeholder="전공" onchange="updateGraduateSchool(${index}, 'major', this.value)">
+        </div>
+        <div class="form-group">
+          <label class="checkbox-label">
+            <input type="checkbox" onchange="updateGraduateSchool(${index}, 'isCurrent', this.checked)">
+            <span>재학중</span>
+          </label>
+        </div>
+      </div>
+    `;
 
     container.appendChild(graduateDiv);
     formData.graduateSchools.push({
@@ -781,48 +1045,48 @@
     const careerDiv = document.createElement('div');
     careerDiv.className = 'dynamic-item';
     careerDiv.innerHTML = `
-                <button type="button" class="remove-btn" onclick="removeCareer(${index})">×</button>
-                <div class="form-content">
-                    <div class="form-row">
-                        <div class="form-group">
-                            <label>회사명</label>
-                            <input type="text" placeholder="회사명" onchange="updateCareer(${index}, 'companyName', this.value)">
-                        </div>
-                        <div class="form-group">
-                            <label>부서</label>
-                            <input type="text" placeholder="부서" onchange="updateCareer(${index}, 'department', this.value)">
-                        </div>
-                    </div>
-                    <div class="form-row">
-                        <div class="form-group">
-                            <label>입사일</label>
-                            <input type="date" data-field="start" onchange="updateCareer(${index}, 'startDate', this.value)">
-                        </div>
-                        <div class="form-group">
-                            <label>퇴사일</label>
-                            <input type="date" data-field="end" onchange="updateCareer(${index}, 'endDate', this.value)">
-                        </div>
-                    </div>
-                    <div class="form-group">
-                        <label>직급</label>
-                        <input type="text" placeholder="직급" onchange="updateCareer(${index}, 'positionTitle', this.value)">
-                    </div>
-                    <div class="form-group">
-                        <label class="checkbox-label">
-                            <input type="checkbox" onchange="updateCareer(${index}, 'isCurrent', this.checked)">
-                            <span>재직중</span>
-                        </label>
-                    </div>
-                    <div class="form-group">
-                        <label>담당업무</label>
-                        <textarea placeholder="담당업무를 상세히 입력하세요" rows="3" onchange="updateCareer(${index}, 'responsibilities', this.value)"></textarea>
-                    </div>
-                    <div class="form-group">
-                        <label>퇴사 사유</label>
-                        <input type="text" placeholder="퇴사 사유" onchange="updateCareer(${index}, 'resignationReason', this.value)">
-                    </div>
-                </div>
-            `;
+      <button type="button" class="remove-btn" onclick="removeCareer(${index})">×</button>
+      <div class="form-content">
+        <div class="form-row">
+          <div class="form-group">
+            <label>회사명</label>
+            <input type="text" placeholder="회사명" onchange="updateCareer(${index}, 'companyName', this.value)">
+          </div>
+          <div class="form-group">
+            <label>부서</label>
+            <input type="text" placeholder="부서" onchange="updateCareer(${index}, 'department', this.value)">
+          </div>
+        </div>
+        <div class="form-row">
+          <div class="form-group">
+            <label>입사일</label>
+            <input type="date" data-field="start" onchange="updateCareer(${index}, 'startDate', this.value)">
+          </div>
+          <div class="form-group">
+            <label>퇴사일</label>
+            <input type="date" data-field="end" onchange="updateCareer(${index}, 'endDate', this.value)">
+          </div>
+        </div>
+        <div class="form-group">
+          <label>직급</label>
+          <input type="text" placeholder="직급" onchange="updateCareer(${index}, 'positionTitle', this.value)">
+        </div>
+        <div class="form-group">
+          <label class="checkbox-label">
+            <input type="checkbox" onchange="updateCareer(${index}, 'isCurrent', this.checked)">
+            <span>재직중</span>
+          </label>
+        </div>
+        <div class="form-group">
+          <label>담당업무</label>
+          <textarea placeholder="담당업무를 상세히 입력하세요" rows="3" onchange="updateCareer(${index}, 'responsibilities', this.value)"></textarea>
+        </div>
+        <div class="form-group">
+          <label>퇴사 사유</label>
+          <input type="text" placeholder="퇴사 사유" onchange="updateCareer(${index}, 'resignationReason', this.value)">
+        </div>
+      </div>
+    `;
 
     container.appendChild(careerDiv);
     formData.careers.push({
@@ -868,40 +1132,40 @@
     const experienceDiv = document.createElement('div');
     experienceDiv.className = 'dynamic-item';
     experienceDiv.innerHTML = `
-                <button type="button" class="remove-btn" onclick="removeExperience(${index})">×</button>
-                <div class="form-content">
-                    <div class="form-row">
-                        <div class="form-group">
-                            <label>활동명</label>
-                            <input type="text" placeholder="활동명" onchange="updateExperience(${index}, 'activityName', this.value)">
-                        </div>
-                        <div class="form-group">
-                            <label>기관/장소</label>
-                            <input type="text" placeholder="기관명 또는 장소" onchange="updateExperience(${index}, 'institution', this.value)">
-                        </div>
-                    </div>
-                    <div class="form-row">
-                        <div class="form-group">
-                            <label>시작일</label>
-                            <input type="date" data-field="start" onchange="updateExperience(${index}, 'startDate', this.value)">
-                        </div>
-                        <div class="form-group">
-                            <label>종료일</label>
-                            <input type="date" data-field="end" onchange="updateExperience(${index}, 'endDate', this.value)">
-                        </div>
-                    </div>
-                    <div class="form-group">
-                        <label class="checkbox-label">
-                            <input type="checkbox" onchange="updateExperience(${index}, 'isCurrent', this.checked)">
-                            <span>진행중</span>
-                        </label>
-                    </div>
-                    <div class="form-group">
-                        <label>내용</label>
-                        <textarea placeholder="활동 내용을 상세히 입력하세요" rows="3" onchange="updateExperience(${index}, 'content', this.value)"></textarea>
-                    </div>
-                </div>
-            `;
+      <button type="button" class="remove-btn" onclick="removeExperience(${index})">×</button>
+      <div class="form-content">
+        <div class="form-row">
+          <div class="form-group">
+            <label>활동명</label>
+            <input type="text" placeholder="활동명" onchange="updateExperience(${index}, 'activityName', this.value)">
+          </div>
+          <div class="form-group">
+            <label>기관/장소</label>
+            <input type="text" placeholder="기관명 또는 장소" onchange="updateExperience(${index}, 'institution', this.value)">
+          </div>
+        </div>
+        <div class="form-row">
+          <div class="form-group">
+            <label>시작일</label>
+            <input type="date" data-field="start" onchange="updateExperience(${index}, 'startDate', this.value)">
+          </div>
+          <div class="form-group">
+            <label>종료일</label>
+            <input type="date" data-field="end" onchange="updateExperience(${index}, 'endDate', this.value)">
+          </div>
+        </div>
+        <div class="form-group">
+          <label class="checkbox-label">
+            <input type="checkbox" onchange="updateExperience(${index}, 'isCurrent', this.checked)">
+            <span>진행중</span>
+          </label>
+        </div>
+        <div class="form-group">
+          <label>내용</label>
+          <textarea placeholder="활동 내용을 상세히 입력하세요" rows="3" onchange="updateExperience(${index}, 'content', this.value)"></textarea>
+        </div>
+      </div>
+    `;
 
     container.appendChild(experienceDiv);
     formData.experiences.push({
@@ -948,7 +1212,7 @@
 
     const submitBtn = document.querySelector('.submit-btn');
     submitBtn.disabled = true;
-    submitBtn.textContent = '생성 중...';
+    submitBtn.textContent = isEditMode ? '수정 중...' : '생성 중...';
 
     try {
       console.log('=== 제출 전 데이터 검증 ===');
@@ -961,7 +1225,7 @@
 
       // 정리된 요청 데이터 준비
       const requestData = {
-        title: formData.title || `이력서 ${String(resumeCounter).padStart(2, '0')}`,
+        title: formData.title || (isEditMode ? '이력서' : `이력서 ${String(resumeCounter).padStart(2, '0')}`),
         industry: cleanStringValue(formData.industry),
         position: cleanStringValue(formData.position),
         targetCompany: cleanStringValue(formData.targetCompany),
@@ -970,26 +1234,49 @@
 
       console.log('전송할 요청 데이터:', requestData);
 
-      // 1. 이력서 기본 정보 저장
-      const resumeResponse = await fetch('/api/resumes', {
-        method: 'POST',
-        headers: getCSRFHeaders(),
-        body: JSON.stringify(requestData)
-      });
+      let resumeId;
 
-      if (!resumeResponse.ok) {
-        // 에러 응답의 상세 정보 출력
-        const errorText = await resumeResponse.text();
-        console.error('Resume API Error:', {
-          status: resumeResponse.status,
-          statusText: resumeResponse.statusText,
-          errorBody: errorText
+      if (isEditMode) {
+        // 기존 이력서 수정
+        const resumeResponse = await fetch(`/api/resumes/${currentResumeId}`, {
+          method: 'PUT',
+          headers: getCSRFHeaders(),
+          body: JSON.stringify(requestData)
         });
-        throw new Error(`이력서 저장에 실패했습니다. (${resumeResponse.status}): ${errorText}`);
-      }
 
-      const resume = await resumeResponse.json();
-      const resumeId = resume.id;
+        if (!resumeResponse.ok) {
+          const errorText = await resumeResponse.text();
+          console.error('Resume Update API Error:', {
+            status: resumeResponse.status,
+            statusText: resumeResponse.statusText,
+            errorBody: errorText
+          });
+          throw new Error(`이력서 수정에 실패했습니다. (${resumeResponse.status}): ${errorText}`);
+        }
+
+        const resume = await resumeResponse.json();
+        resumeId = resume.id;
+      } else {
+        // 새 이력서 생성
+        const resumeResponse = await fetch('/api/resumes', {
+          method: 'POST',
+          headers: getCSRFHeaders(),
+          body: JSON.stringify(requestData)
+        });
+
+        if (!resumeResponse.ok) {
+          const errorText = await resumeResponse.text();
+          console.error('Resume API Error:', {
+            status: resumeResponse.status,
+            statusText: resumeResponse.statusText,
+            errorBody: errorText
+          });
+          throw new Error(`이력서 저장에 실패했습니다. (${resumeResponse.status}): ${errorText}`);
+        }
+
+        const resume = await resumeResponse.json();
+        resumeId = resume.id;
+      }
 
       // 2. 고등학교 정보 저장 (학교명이 실제로 입력된 경우만)
       if (formData.highschool.schoolName && formData.highschool.schoolName.trim() !== '') {
@@ -1092,10 +1379,12 @@
         console.warn('자소서 생성에 실패했지만 이력서는 저장되었습니다.');
       }
 
-      alert('이력서가 성공적으로 저장되었습니다!');
+      alert(isEditMode ? '이력서가 성공적으로 수정되었습니다!' : '이력서가 성공적으로 저장되었습니다!');
 
-      // 다음 이력서를 위해 카운터 증가
-      resumeCounter++;
+      // 다음 이력서를 위해 카운터 증가 (새 작성인 경우만)
+      if (!isEditMode) {
+        resumeCounter++;
+      }
 
       // Gemini 결과 페이지로 이동
       window.location.href = `/resumes/result?resumeId=${resumeId}`;
@@ -1105,11 +1394,11 @@
       if (error.name === 'SyntaxError' && error.message.includes('Unexpected token')) {
         alert('서버 응답 형식이 올바르지 않습니다. 관리자에게 문의하세요.');
       } else {
-        alert('저장 중 오류가 발생했습니다: ' + error.message);
+        alert(`${isEditMode ? '수정' : '저장'} 중 오류가 발생했습니다: ` + error.message);
       }
     } finally {
       submitBtn.disabled = false;
-      submitBtn.textContent = 'AI 이력서 생성';
+      submitBtn.textContent = isEditMode ? 'AI 이력서 수정' : 'AI 이력서 생성';
     }
   }
 

--- a/src/main/resources/templates/resume/resume-list.html
+++ b/src/main/resources/templates/resume/resume-list.html
@@ -1,0 +1,1098 @@
+<!DOCTYPE html>
+<html lang="ko">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="_csrf" th:content="${_csrf.token}"/>
+  <meta name="_csrf_header" th:content="${_csrf.headerName}"/>
+  <title>자소서 목록</title>
+  <style>
+    * {
+      margin: 0;
+      padding: 0;
+      box-sizing: border-box;
+    }
+
+    body {
+      font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+      background-color: #f8f9fa;
+      line-height: 1.6;
+      color: #333;
+    }
+
+    .header {
+      background: white;
+      border-bottom: 1px solid #e5e7eb;
+      padding: 2rem 0;
+    }
+
+    .header-content {
+      max-width: 1200px;
+      margin: 0 auto;
+      padding: 0 1rem;
+      display: flex;
+      justify-content: space-between;
+      align-items: center;
+    }
+
+    .header-left h1 {
+      font-size: 1.75rem;
+      font-weight: 700;
+      color: #1f2937;
+      margin-bottom: 0.5rem;
+    }
+
+    .header-left p {
+      color: #6b7280;
+      font-size: 0.95rem;
+    }
+
+    .new-resume-btn {
+      background: #3b82f6;
+      color: white;
+      padding: 0.5rem 1rem;
+      border-radius: 0.375rem;
+      border: none;
+      font-weight: 500;
+      cursor: pointer;
+      text-decoration: none;
+      display: inline-flex;
+      align-items: center;
+      gap: 0.375rem;
+      transition: background-color 0.2s ease;
+      font-size: 0.875rem;
+    }
+
+    .new-resume-btn:hover {
+      background: #2563eb;
+    }
+
+    .container {
+      max-width: 1200px;
+      margin: 0 auto;
+      padding: 2rem 1rem;
+    }
+
+    /* 통계 섹션 */
+    .stats-section {
+      display: grid;
+      grid-template-columns: repeat(3, 1fr);
+      gap: 1.5rem;
+      margin-bottom: 2rem;
+    }
+
+    .stat-card {
+      background: white;
+      border-radius: 0.75rem;
+      padding: 1.5rem;
+      text-align: center;
+      box-shadow: 0 1px 3px rgba(0, 0, 0, 0.1);
+      border-left: 4px solid;
+    }
+
+    .stat-card.total { border-left-color: #3b82f6; }
+    .stat-card.completed { border-left-color: #10b981; }
+    .stat-card.in-progress { border-left-color: #f59e0b; }
+
+    .stat-number {
+      font-size: 2.5rem;
+      font-weight: 800;
+      margin-bottom: 0.5rem;
+    }
+
+    .stat-card.total .stat-number { color: #3b82f6; }
+    .stat-card.completed .stat-number { color: #10b981; }
+    .stat-card.in-progress .stat-number { color: #f59e0b; }
+
+    .stat-label {
+      color: #6b7280;
+      font-size: 0.875rem;
+      font-weight: 500;
+    }
+
+    /* 필터 및 검색 섹션 */
+    .filter-section {
+      background: white;
+      border-radius: 0.75rem;
+      padding: 1.5rem;
+      margin-bottom: 2rem;
+      box-shadow: 0 1px 3px rgba(0, 0, 0, 0.1);
+    }
+
+    .search-bar {
+      display: flex;
+      gap: 1rem;
+      margin-bottom: 1.5rem;
+      align-items: center;
+    }
+
+    .search-input {
+      flex: 1;
+      padding: 0.75rem 1rem;
+      border: 1px solid #d1d5db;
+      border-radius: 0.5rem;
+      font-size: 0.875rem;
+      background: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="%236b7280" viewBox="0 0 16 16"><path d="M11.742 10.344a6.5 6.5 0 1 0-1.397 1.398h-.001c.03.04.062.078.098.115l3.85 3.85a1 1 0 0 0 1.415-1.414l-3.85-3.85a1.007 1.007 0 0 0-.115-.1zM12 6.5a5.5 5.5 0 1 1-11 0 5.5 5.5 0 0 1 11 0z"/></svg>') no-repeat 1rem center;
+      padding-left: 2.5rem;
+    }
+
+    .search-input:focus {
+      outline: none;
+      border-color: #3b82f6;
+      box-shadow: 0 0 0 3px rgba(59, 130, 246, 0.1);
+    }
+
+    .filter-buttons {
+      display: flex;
+      justify-content: space-between;
+      align-items: center;
+      flex-wrap: wrap;
+      gap: 1rem;
+    }
+
+    .filter-group {
+      display: flex;
+      gap: 0.5rem;
+      align-items: center;
+    }
+
+    .filter-group.left {
+      flex: 1;
+    }
+
+    .filter-group.right {
+      flex-shrink: 0;
+    }
+
+    .filter-btn {
+      padding: 0.5rem 1rem;
+      border: 1px solid #d1d5db;
+      background: white;
+      border-radius: 0.5rem;
+      font-size: 0.875rem;
+      cursor: pointer;
+      transition: all 0.2s ease;
+      color: #6b7280;
+    }
+
+    .filter-btn:hover {
+      border-color: #3b82f6;
+      color: #3b82f6;
+    }
+
+    .filter-btn.active {
+      background: #3b82f6;
+      border-color: #3b82f6;
+      color: white;
+    }
+
+    .sort-dropdown {
+      position: relative;
+    }
+
+    .sort-button {
+      padding: 0.5rem 1rem;
+      border: 1px solid #d1d5db;
+      background: white;
+      border-radius: 0.5rem;
+      font-size: 0.875rem;
+      cursor: pointer;
+      transition: all 0.2s ease;
+      color: #374151;
+      display: flex;
+      align-items: center;
+      gap: 0.5rem;
+      min-width: 100px;
+      justify-content: space-between;
+    }
+
+    .sort-button:hover {
+      border-color: #3b82f6;
+      color: #3b82f6;
+    }
+
+    .sort-button .arrow {
+      font-size: 0.6rem;
+      color: #9ca3af;
+      transition: transform 0.2s ease;
+    }
+
+    .sort-dropdown.show .sort-button .arrow {
+      transform: rotate(180deg);
+    }
+
+    .sort-dropdown-menu {
+      position: absolute;
+      top: 100%;
+      right: 0;
+      background: white;
+      border: 1px solid #e5e7eb;
+      border-radius: 0.5rem;
+      box-shadow: 0 4px 6px rgba(0, 0, 0, 0.1);
+      z-index: 10;
+      min-width: 120px;
+      display: none;
+    }
+
+    .sort-dropdown-menu.show {
+      display: block;
+    }
+
+    .sort-option {
+      padding: 0.75rem 1rem;
+      cursor: pointer;
+      font-size: 0.875rem;
+      border: none;
+      background: none;
+      width: 100%;
+      text-align: left;
+      transition: background-color 0.2s ease;
+    }
+
+    .sort-option:hover {
+      background: #f3f4f6;
+    }
+
+    .sort-option:first-child {
+      border-radius: 0.5rem 0.5rem 0 0;
+    }
+
+    .sort-option:last-child {
+      border-radius: 0 0 0.5rem 0.5rem;
+    }
+
+    /* 자소서 그리드 */
+    .resume-grid {
+      display: grid;
+      grid-template-columns: repeat(auto-fill, minmax(350px, 1fr));
+      gap: 1.5rem;
+      margin-bottom: 2rem;
+    }
+
+    .resume-card {
+      background: white;
+      border-radius: 0.75rem;
+      padding: 1.5rem;
+      box-shadow: 0 1px 3px rgba(0, 0, 0, 0.1);
+      transition: all 0.2s ease;
+      cursor: pointer;
+      border: 1px solid #e5e7eb;
+      position: relative;
+    }
+
+    .resume-card:hover {
+      box-shadow: 0 4px 12px rgba(0, 0, 0, 0.15);
+      transform: translateY(-2px);
+    }
+
+    .resume-title {
+      font-size: 1.125rem;
+      font-weight: 600;
+      color: #1f2937;
+      margin-bottom: 0.5rem;
+    }
+
+    .resume-company {
+      font-size: 0.875rem;
+      color: #6b7280;
+      margin-bottom: 1rem;
+    }
+
+    .status-badge {
+      display: inline-block;
+      font-size: 0.75rem;
+      font-weight: 500;
+      padding: 0.25rem 0.75rem;
+      border-radius: 0.5rem;
+      margin-bottom: 1.5rem;
+    }
+
+    .status-completed {
+      background: #d1fae5;
+      color: #065f46;
+    }
+
+    .status-writing {
+      background: #fef3c7;
+      color: #92400e;
+    }
+
+    .resume-dates {
+      display: flex;
+      justify-content: space-between;
+      font-size: 0.75rem;
+      color: #9ca3af;
+      padding-top: 1rem;
+      border-top: 1px solid #f3f4f6;
+    }
+
+    .resume-actions {
+      display: none;
+      position: absolute;
+      top: 1.5rem;
+      right: 1.5rem;
+      gap: 0.5rem;
+      align-items: flex-start;
+    }
+
+    .resume-card:hover .resume-actions {
+      display: flex;
+    }
+
+    .action-btn {
+      width: 2rem;
+      height: 2rem;
+      border: none;
+      border-radius: 0.25rem;
+      cursor: pointer;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      font-size: 0.875rem;
+      transition: all 0.2s ease;
+    }
+
+    .edit-btn {
+      background: #eff6ff;
+      color: #2563eb;
+    }
+
+    .edit-btn:hover {
+      background: #dbeafe;
+    }
+
+    .delete-btn {
+      background: #fef2f2;
+      color: #dc2626;
+    }
+
+    .delete-btn:hover {
+      background: #fecaca;
+    }
+
+    /* 페이지네이션 */
+    .pagination {
+      display: flex;
+      justify-content: center;
+      align-items: center;
+      gap: 0.5rem;
+      margin-top: 2rem;
+    }
+
+    .page-btn {
+      width: 2.5rem;
+      height: 2.5rem;
+      border: 1px solid #d1d5db;
+      background: white;
+      border-radius: 0.375rem;
+      cursor: pointer;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      font-size: 0.875rem;
+      transition: all 0.2s ease;
+    }
+
+    .page-btn:hover {
+      border-color: #3b82f6;
+      color: #3b82f6;
+    }
+
+    .page-btn.active {
+      background: #3b82f6;
+      border-color: #3b82f6;
+      color: white;
+    }
+
+    .page-btn:disabled {
+      opacity: 0.5;
+      cursor: not-allowed;
+    }
+
+    /* 빈 상태 및 에러 상태 */
+    .empty-state {
+      display: none;
+      flex-direction: column;
+      align-items: center;
+      justify-content: center;
+      text-align: center;
+      padding: 4rem 2rem;
+      background: white;
+      border-radius: 0.75rem;
+      box-shadow: 0 1px 3px rgba(0, 0, 0, 0.1);
+      margin: 2rem 0;
+    }
+
+    .empty-state .icon {
+      font-size: 4rem;
+      margin-bottom: 1.5rem;
+      opacity: 0.6;
+    }
+
+    .empty-state h3 {
+      font-size: 1.25rem;
+      font-weight: 600;
+      color: #374151;
+      margin-bottom: 0.75rem;
+      line-height: 1.4;
+    }
+
+    .empty-state p {
+      color: #6b7280;
+      font-size: 1rem;
+      line-height: 1.5;
+      max-width: 400px;
+    }
+
+    .empty-state .retry-btn {
+      margin-top: 1.5rem;
+      padding: 0.75rem 1.5rem;
+      background: #3b82f6;
+      color: white;
+      border: none;
+      border-radius: 0.5rem;
+      font-weight: 500;
+      cursor: pointer;
+      transition: background-color 0.2s ease;
+    }
+
+    .empty-state .retry-btn:hover {
+      background: #2563eb;
+    }
+
+    /* 로딩 상태 */
+    .loading {
+      display: flex;
+      justify-content: center;
+      align-items: center;
+      padding: 4rem;
+      color: #6b7280;
+    }
+
+    .spinner {
+      width: 24px;
+      height: 24px;
+      border: 3px solid #e5e7eb;
+      border-radius: 50%;
+      border-top-color: #3b82f6;
+      animation: spin 1s ease-in-out infinite;
+      margin-right: 0.75rem;
+    }
+
+    @keyframes spin {
+      to { transform: rotate(360deg); }
+    }
+
+    /* 반응형 디자인 */
+    @media (max-width: 768px) {
+      .header-content {
+        flex-direction: column;
+        gap: 1rem;
+        text-align: center;
+      }
+
+      .stats-section {
+        grid-template-columns: repeat(3, 1fr);
+      }
+
+      .search-bar {
+        flex-direction: column;
+      }
+
+      .filter-buttons {
+        flex-direction: column;
+        gap: 1rem;
+        align-items: stretch;
+      }
+
+      .filter-group.left,
+      .filter-group.right {
+        justify-content: center;
+        flex-wrap: wrap;
+        flex: none;
+      }
+
+      .sort-dropdown-menu {
+        right: auto;
+        left: 0;
+      }
+
+      .resume-grid {
+        grid-template-columns: 1fr;
+      }
+
+      .pagination {
+        flex-wrap: wrap;
+      }
+
+      .resume-actions {
+        position: static;
+        display: flex;
+        justify-content: flex-end;
+        margin-top: 1rem;
+      }
+
+      .empty-state {
+        margin: 1rem 0;
+        padding: 2rem 1rem;
+      }
+
+      .empty-state .icon {
+        font-size: 3rem;
+        margin-bottom: 1rem;
+      }
+
+      .empty-state h3 {
+        font-size: 1.125rem;
+      }
+
+      .empty-state p {
+        font-size: 0.875rem;
+      }
+    }
+
+    @media (max-width: 480px) {
+      .stats-section {
+        grid-template-columns: 1fr;
+      }
+
+      .empty-state {
+        padding: 1.5rem 1rem;
+      }
+
+      .empty-state .icon {
+        font-size: 2.5rem;
+      }
+
+      .empty-state h3 {
+        font-size: 1rem;
+      }
+
+      .empty-state p {
+        font-size: 0.8rem;
+      }
+
+      .empty-state .retry-btn {
+        padding: 0.625rem 1.25rem;
+        font-size: 0.875rem;
+      }
+    }
+  </style>
+</head>
+<body>
+<div class="header">
+  <div class="header-content">
+    <div class="header-left">
+      <h1>자소서 목록</h1>
+      <p>나의 모든 자소서를 한 곳에서 체계적으로 관리하세요</p>
+    </div>
+    <a href="/resumes/create" class="new-resume-btn">
+      ✏️ 새 자소서 작성
+    </a>
+  </div>
+</div>
+
+<div class="container">
+  <!-- 통계 섹션 -->
+  <div class="stats-section">
+    <div class="stat-card total">
+      <div class="stat-number" id="totalCount">0</div>
+      <div class="stat-label">전체 자소서</div>
+    </div>
+    <div class="stat-card completed">
+      <div class="stat-number" id="completedCount">0</div>
+      <div class="stat-label">완료된 자소서</div>
+    </div>
+    <div class="stat-card in-progress">
+      <div class="stat-number" id="writingCount">0</div>
+      <div class="stat-label">작성중</div>
+    </div>
+  </div>
+
+  <!-- 필터 및 검색 섹션 -->
+  <div class="filter-section">
+    <div class="search-bar">
+      <input
+              type="text"
+              class="search-input"
+              placeholder="회사명이나 자소서 제목으로 검색해보세요"
+              id="searchInput"
+      >
+    </div>
+    <div class="filter-buttons">
+      <div class="filter-group left">
+        <button class="filter-btn active" data-filter="all">전체</button>
+        <button class="filter-btn" data-filter="completed">완료</button>
+        <button class="filter-btn" data-filter="writing">작성중</button>
+      </div>
+
+      <div class="filter-group right">
+        <div class="sort-dropdown">
+          <button class="sort-button" id="sortButton">
+            <span id="sortButtonText">최신순</span>
+            <span class="arrow">▼</span>
+          </button>
+          <div class="sort-dropdown-menu" id="sortDropdown">
+            <button class="sort-option" data-sort="newest">최신순</button>
+            <button class="sort-option" data-sort="oldest">오래된순</button>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+
+  <!-- 로딩 상태 -->
+  <div id="loadingState" class="loading">
+    <div class="spinner"></div>
+    자소서 목록을 불러오는 중...
+  </div>
+
+  <!-- 자소서 그리드 -->
+  <div id="resumeGrid" class="resume-grid" style="display: none;">
+    <!-- 자소서 카드들이 동적으로 생성됩니다 -->
+  </div>
+
+  <!-- 빈 상태 -->
+  <div id="emptyState" class="empty-state" style="display: none;">
+    <div class="icon">📝</div>
+    <h3 id="emptyTitle">아직 작성된 자소서가 없습니다</h3>
+    <p id="emptyMessage">첫 번째 자소서를 작성해보세요!</p>
+    <button id="retryBtn" class="retry-btn" style="display: none;" onclick="loadResumes()">다시 시도</button>
+  </div>
+
+  <!-- 페이지네이션 -->
+  <div id="pagination" class="pagination" style="display: none;">
+    <!-- 페이지네이션 버튼들이 동적으로 생성됩니다 -->
+  </div>
+</div>
+
+<script>
+  let currentFilter = 'all';
+  let currentSort = 'newest';
+  let currentPage = 1;
+  let resumes = [];
+  let filteredResumes = [];
+
+  // CSRF 토큰 가져오기
+  function getCSRFHeaders() {
+    const token = document.querySelector('meta[name="_csrf"]')?.getAttribute('content');
+    const header = document.querySelector('meta[name="_csrf_header"]')?.getAttribute('content');
+
+    const headers = {
+      'Content-Type': 'application/json'
+    };
+
+    if (token && header) {
+      headers[header] = token;
+    }
+
+    return headers;
+  }
+
+  // 자소서 목록 불러오기
+  async function loadResumes() {
+    try {
+      showLoading();
+
+      const response = await fetch('/api/resumes', {
+        method: 'GET',
+        headers: getCSRFHeaders()
+      });
+
+      if (response.ok) {
+        resumes = await response.json();
+        updateStats();
+        applyFilters();
+        renderResumes();
+        hideLoading();
+      } else if (response.status === 401 || response.status === 403) {
+        // 로그인 필요
+        hideLoading();
+        showEmptyState(true, '로그인이 필요합니다. 로그인 후 다시 시도해주세요.');
+      }  else {
+        throw new Error(`서버 오류 (${response.status})`);
+      }
+    } catch (error) {
+      console.error('Load error:', error);
+      hideLoading();
+
+      if (error.name === 'TypeError' && error.message.includes('fetch')) {
+        // 네트워크 오류
+        showEmptyState(true, '네트워크 연결을 확인해주세요.');
+      }
+    }
+  }
+
+  // 페이지 초기화
+  async function init() {
+    await loadResumes();
+    setupEventListeners();
+  }
+
+  // 자소서 상태 판단
+  function getResumeStatus(resume) {
+    // 백엔드에서 status 필드를 제공하는 경우
+    if (resume.status) {
+      // 백엔드 상태를 프론트엔드 상태로 매핑
+      const statusMapping = {
+        'COMPLETED': 'completed',
+        'TEMP_SAVED': 'writing',
+        'IN_PROGRESS': 'writing',
+        'DRAFT': 'writing'
+      };
+
+      const mappedStatus = statusMapping[resume.status];
+      if (mappedStatus) {
+        return mappedStatus;
+      }
+    }
+
+    // 섹션 기반으로 상태 판단
+    const sections = resume.sections || [];
+    const totalSections = sections.length;
+
+    if (totalSections === 0) return 'writing';
+
+    const completedSections = sections.filter(s =>
+            s.content && s.content.trim().length > 100
+    ).length;
+
+    const progress = totalSections > 0 ? (completedSections / totalSections) * 100 : 0;
+
+    if (progress >= 80) return 'completed';
+    return 'writing';
+  }
+
+  // 통계 업데이트
+  function updateStats() {
+    const total = resumes.length;
+    const completed = resumes.filter(r => getResumeStatus(r) === 'completed').length;
+    const writing = resumes.filter(r => getResumeStatus(r) === 'writing').length;
+
+    document.getElementById('totalCount').textContent = total;
+    document.getElementById('completedCount').textContent = completed;
+    document.getElementById('writingCount').textContent = writing;
+  }
+
+  // 이벤트 리스너 설정
+  function setupEventListeners() {
+    // 검색
+    document.getElementById('searchInput').addEventListener('input', function() {
+      applyFilters();
+      renderResumes();
+    });
+
+    // 필터 버튼
+    document.querySelectorAll('[data-filter]').forEach(btn => {
+      btn.addEventListener('click', function() {
+        document.querySelectorAll('[data-filter]').forEach(b => b.classList.remove('active'));
+        this.classList.add('active');
+        currentFilter = this.dataset.filter;
+
+        currentPage = 1;
+        applyFilters();
+        renderResumes();
+      });
+    });
+
+    // 정렬 드롭다운
+    const sortButton = document.getElementById('sortButton');
+    const sortDropdown = document.getElementById('sortDropdown');
+
+    sortButton.addEventListener('click', function(e) {
+      e.stopPropagation();
+      const dropdown = sortDropdown.closest('.sort-dropdown');
+      dropdown.classList.toggle('show');
+      sortDropdown.classList.toggle('show');
+    });
+
+    // 정렬 옵션 선택
+    document.querySelectorAll('.sort-option').forEach(option => {
+      option.addEventListener('click', function() {
+        const sortText = this.textContent;
+        const sortValue = this.dataset.sort;
+
+        document.getElementById('sortButtonText').textContent = sortText;
+        currentSort = sortValue;
+
+        const dropdown = sortDropdown.closest('.sort-dropdown');
+        dropdown.classList.remove('show');
+        sortDropdown.classList.remove('show');
+
+        currentPage = 1;
+        applyFilters();
+        renderResumes();
+      });
+    });
+
+    // 드롭다운 외부 클릭시 닫기
+    document.addEventListener('click', function() {
+      const dropdown = document.querySelector('.sort-dropdown');
+      dropdown.classList.remove('show');
+      document.getElementById('sortDropdown').classList.remove('show');
+    });
+  }
+
+  // 필터 적용
+  function applyFilters() {
+    let filtered = [...resumes];
+
+    // 검색 필터
+    const searchTerm = document.getElementById('searchInput').value.toLowerCase();
+    if (searchTerm) {
+      filtered = filtered.filter(resume =>
+              (resume.title && resume.title.toLowerCase().includes(searchTerm)) ||
+              (resume.targetCompany && resume.targetCompany.toLowerCase().includes(searchTerm))
+      );
+    }
+
+    // 상태 필터
+    if (currentFilter !== 'all') {
+      filtered = filtered.filter(resume => getResumeStatus(resume) === currentFilter);
+    }
+
+    // 정렬 (날짜 필드 호환성 처리)
+    filtered.sort((a, b) => {
+      // snake_case와 camelCase 모두 지원
+      const aDate = new Date(a.updated_at || a.updatedAt || a.created_at || a.createdAt);
+      const bDate = new Date(b.updated_at || b.updatedAt || b.created_at || b.createdAt);
+
+      if (currentSort === 'newest') {
+        return bDate - aDate;
+      } else {
+        return aDate - bDate;
+      }
+    });
+
+    filteredResumes = filtered;
+  }
+
+  // 자소서 목록 렌더링
+  function renderResumes() {
+    const grid = document.getElementById('resumeGrid');
+
+    if (filteredResumes.length === 0) {
+      showEmptyState(false); // 일반적인 빈 상태
+      return;
+    }
+
+    // 페이지네이션 설정
+    const itemsPerPage = 10;
+    const totalPages = Math.ceil(filteredResumes.length / itemsPerPage);
+    const startIndex = (currentPage - 1) * itemsPerPage;
+    const endIndex = startIndex + itemsPerPage;
+    const pageResumes = filteredResumes.slice(startIndex, endIndex);
+
+    grid.innerHTML = '';
+    grid.style.display = 'grid';
+
+    pageResumes.forEach(resume => {
+      const card = createResumeCard(resume);
+      grid.appendChild(card);
+    });
+
+    renderPagination(totalPages);
+    hideEmptyState();
+  }
+
+  // 자소서 카드 생성
+  function createResumeCard(resume) {
+    const status = getResumeStatus(resume);
+
+    const statusLabels = {
+      'completed': '완료',
+      'writing': '작성중'
+    };
+
+    const card = document.createElement('div');
+    card.className = 'resume-card';
+    card.onclick = () => viewResume(resume.id);
+
+    // 날짜 필드 처리 (snake_case와 camelCase 모두 지원)
+    const createdDate = resume.created_at || resume.createdAt;
+    const updatedDate = resume.updated_at || resume.updatedAt;
+
+    card.innerHTML = `
+        <div class="resume-title">${resume.title || '제목 없음'}</div>
+        <div class="resume-company">${resume.targetCompany || '회사명 미설정'} • ${resume.position || '직무 미설정'}</div>
+
+        <span class="status-badge status-${status}">${statusLabels[status]}</span>
+
+        <div class="resume-dates">
+          <span>작성일: ${formatDate(createdDate)}</span>
+          <span>수정일: ${formatDate(updatedDate)}</span>
+        </div>
+
+        <div class="resume-actions">
+          <button class="action-btn edit-btn" onclick="event.stopPropagation(); editResume(${resume.id})" title="수정">
+            ✏️
+          </button>
+          <button class="action-btn delete-btn" onclick="event.stopPropagation(); deleteResume(${resume.id})" title="삭제">
+            🗑️
+          </button>
+        </div>
+      `;
+
+    return card;
+  }
+
+  // 페이지네이션 렌더링
+  function renderPagination(totalPages) {
+    const pagination = document.getElementById('pagination');
+
+    if (totalPages <= 1) {
+      pagination.style.display = 'none';
+      return;
+    }
+
+    pagination.style.display = 'flex';
+    pagination.innerHTML = '';
+
+    // 이전 버튼
+    const prevBtn = document.createElement('button');
+    prevBtn.className = 'page-btn';
+    prevBtn.textContent = '<';
+    prevBtn.disabled = currentPage === 1;
+    prevBtn.onclick = () => changePage(currentPage - 1);
+    pagination.appendChild(prevBtn);
+
+    // 페이지 번호들
+    const startPage = Math.max(1, currentPage - 2);
+    const endPage = Math.min(totalPages, currentPage + 2);
+
+    for (let i = startPage; i <= endPage; i++) {
+      const pageBtn = document.createElement('button');
+      pageBtn.className = `page-btn ${i === currentPage ? 'active' : ''}`;
+      pageBtn.textContent = i;
+      pageBtn.onclick = () => changePage(i);
+      pagination.appendChild(pageBtn);
+    }
+
+    // 다음 버튼
+    const nextBtn = document.createElement('button');
+    nextBtn.className = 'page-btn';
+    nextBtn.textContent = '>';
+    nextBtn.disabled = currentPage === totalPages;
+    nextBtn.onclick = () => changePage(currentPage + 1);
+    pagination.appendChild(nextBtn);
+  }
+
+  // 페이지 변경
+  function changePage(page) {
+    currentPage = page;
+    renderResumes();
+  }
+
+  // 날짜 포맷팅
+  function formatDate(dateString) {
+    if (!dateString) {
+      return '-';
+    }
+
+    try {
+      const date = new Date(dateString);
+      if (isNaN(date.getTime())) {
+        return '-';
+      }
+
+      return date.toLocaleDateString('ko-KR', {
+        year: 'numeric',
+        month: 'short',
+        day: 'numeric'
+      });
+    } catch (error) {
+      console.error('Date formatting error:', error);
+      return '-';
+    }
+  }
+
+  // 자소서 조회
+  function viewResume(resumeId) {
+    window.location.href = `/resumes/result?resumeId=${resumeId}`;
+  }
+
+  // 자소서 수정
+  function editResume(resumeId) {
+    window.location.href = `/resumes/edit?resumeId=${resumeId}`;
+  }
+
+  // 자소서 삭제
+  async function deleteResume(resumeId) {
+    if (!confirm('정말로 이 자소서를 삭제하시겠습니까?')) {
+      return;
+    }
+
+    try {
+      const response = await fetch(`/api/resumes/${resumeId}`, {
+        method: 'DELETE',
+        headers: getCSRFHeaders()
+      });
+
+      if (response.ok) {
+        alert('자소서가 삭제되었습니다.');
+        await loadResumes(); // 목록 새로고침
+      } else {
+        throw new Error('삭제에 실패했습니다.');
+      }
+    } catch (error) {
+      console.error('Delete error:', error);
+
+      // API 오류시 더미 데이터에서만 삭제 (임시)
+      console.warn('API 오류로 인해 임시 데이터에서만 삭제합니다.');
+      resumes = resumes.filter(r => r.id !== resumeId);
+      updateStats();
+      applyFilters();
+      renderResumes();
+      alert('자소서가 삭제되었습니다. (임시 삭제)');
+    }
+  }
+
+  // 로딩 상태 표시/숨김
+  function showLoading() {
+    document.getElementById('loadingState').style.display = 'flex';
+    document.getElementById('resumeGrid').style.display = 'none';
+    hideEmptyState();
+    document.getElementById('pagination').style.display = 'none';
+  }
+
+  function hideLoading() {
+    document.getElementById('loadingState').style.display = 'none';
+  }
+
+  // 빈 상태 표시/숨김
+  function showEmptyState(isError = false, message = null) {
+    const emptyState = document.getElementById('emptyState');
+    const emptyTitle = document.getElementById('emptyTitle');
+    const emptyMessage = document.getElementById('emptyMessage');
+    const retryBtn = document.getElementById('retryBtn');
+    const icon = emptyState.querySelector('.icon');
+
+    emptyState.style.display = 'flex';
+    document.getElementById('resumeGrid').style.display = 'none';
+    document.getElementById('pagination').style.display = 'none';
+
+    if (isError) {
+      // 에러 상태
+      icon.textContent = '⚠️';
+      emptyTitle.textContent = '자소서 목록을 불러오는 중 오류가 발생했습니다';
+      emptyMessage.textContent = message || '네트워크 연결을 확인하고 다시 시도해주세요.';
+      retryBtn.style.display = 'inline-block';
+    } else {
+      // 빈 상태
+      icon.textContent = '📝';
+      emptyTitle.textContent = '아직 작성된 자소서가 없습니다';
+      emptyMessage.textContent = '첫 번째 자소서를 작성해보세요!';
+      retryBtn.style.display = 'none';
+    }
+  }
+
+  function hideEmptyState() {
+    const emptyState = document.getElementById('emptyState');
+    emptyState.style.display = 'none';
+  }
+
+  // 페이지 로드시 초기화
+  document.addEventListener('DOMContentLoaded', init);
+</script>
+</body>
+</html>

--- a/src/main/resources/templates/resume/resume-list.html
+++ b/src/main/resources/templates/resume/resume-list.html
@@ -1013,7 +1013,7 @@
 
   // 자소서 수정
   function editResume(resumeId) {
-    window.location.href = `/resumes/edit?resumeId=${resumeId}`;
+    window.location.href = `/resumes/create?resumeId=${resumeId}`;
   }
 
   // 자소서 삭제

--- a/src/main/resources/templates/resume/resume-list.html
+++ b/src/main/resources/templates/resume/resume-list.html
@@ -298,6 +298,71 @@
       margin-bottom: 1rem;
     }
 
+    /* 상태 선택 드롭다운 */
+    .status-dropdown {
+      position: relative;
+      display: inline-block;
+    }
+
+    .status-dropdown-menu {
+      position: absolute;
+      top: 100%;
+      left: 0;
+      background: white;
+      border: 1px solid #e5e7eb;
+      border-radius: 0.375rem;
+      box-shadow: 0 4px 12px rgba(0, 0, 0, 0.1);
+      z-index: 1000;
+      min-width: 100px;
+      display: none;
+      overflow: hidden;
+    }
+
+    .status-dropdown-menu.show {
+      display: block;
+    }
+
+    .status-option {
+      padding: 0.5rem 0.75rem;
+      cursor: pointer;
+      font-size: 0.75rem;
+      font-weight: 500;
+      border: none;
+      background: none;
+      width: 100%;
+      text-align: left;
+      transition: background-color 0.2s ease;
+      display: flex;
+      align-items: center;
+      gap: 0.5rem;
+    }
+
+    .status-option:hover {
+      background: #f3f4f6;
+    }
+
+    .status-option.completed {
+      color: #065f46;
+    }
+
+    .status-option.writing {
+      color: #92400e;
+    }
+
+    .status-option .status-icon {
+      width: 8px;
+      height: 8px;
+      border-radius: 50%;
+    }
+
+    .status-option.completed .status-icon {
+      background: #10b981;
+    }
+
+    .status-option.writing .status-icon {
+      background: #f59e0b;
+    }
+
     .status-badge {
       display: inline-block;
       font-size: 0.75rem;
@@ -305,16 +370,36 @@
       padding: 0.25rem 0.75rem;
       border-radius: 0.5rem;
       margin-bottom: 1.5rem;
+      cursor: pointer;
+      transition: all 0.2s ease;
+      border: 1px solid transparent;
+      user-select: none;
+      position: relative;
+    }
+
+    .status-badge:hover {
+      transform: scale(1.05);
+      box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
     }
 
     .status-completed {
       background: #d1fae5;
       color: #065f46;
+      border-color: #10b981;
+    }
+
+    .status-completed:hover {
+      background: #a7f3d0;
     }
 
     .status-writing {
       background: #fef3c7;
       color: #92400e;
+      border-color: #f59e0b;
+    }
+
+    .status-writing:hover {
+      background: #fde68a;
     }
 
     .resume-dates {
@@ -481,6 +566,29 @@
 
     @keyframes spin {
       to { transform: rotate(360deg); }
+    }
+
+    /* 상태 변경 알림 */
+    .status-toast {
+      position: fixed;
+      top: 2rem;
+      right: 2rem;
+      background: #10b981;
+      color: white;
+      padding: 0.75rem 1.5rem;
+      border-radius: 0.5rem;
+      font-size: 0.875rem;
+      font-weight: 500;
+      box-shadow: 0 4px 12px rgba(0, 0, 0, 0.1);
+      opacity: 0;
+      transform: translateX(100%);
+      transition: all 0.3s ease;
+      z-index: 1000;
+    }
+
+    .status-toast.show {
+      opacity: 1;
+      transform: translateX(0);
     }
 
     /* 반응형 디자인 */
@@ -666,6 +774,11 @@
   </div>
 </div>
 
+<!-- 상태 변경 알림 토스트 -->
+<div id="statusToast" class="status-toast">
+  상태가 변경되었습니다.
+</div>
+
 <script>
   let currentFilter = 'all';
   let currentSort = 'newest';
@@ -826,10 +939,16 @@
     });
 
     // 드롭다운 외부 클릭시 닫기
-    document.addEventListener('click', function() {
+    document.addEventListener('click', function(e) {
+      // 정렬 드롭다운 닫기
       const dropdown = document.querySelector('.sort-dropdown');
       dropdown.classList.remove('show');
       document.getElementById('sortDropdown').classList.remove('show');
+
+      // 상태 드롭다운 닫기 (상태 드롭다운이 클릭된 경우가 아닐 때만)
+      if (!e.target.closest('.status-dropdown')) {
+        hideAllStatusDropdowns();
+      }
     });
   }
 
@@ -916,7 +1035,21 @@
         <div class="resume-title">${resume.title || '제목 없음'}</div>
         <div class="resume-company">${resume.targetCompany || '회사명 미설정'} • ${resume.position || '직무 미설정'}</div>
 
-        <span class="status-badge status-${status}">${statusLabels[status]}</span>
+        <div class="status-dropdown">
+          <span class="status-badge status-${status}" onclick="event.stopPropagation(); showStatusDropdown(${resume.id})" title="클릭하여 상태 변경">
+            ${statusLabels[status]}
+          </span>
+          <div class="status-dropdown-menu" id="statusDropdown-${resume.id}">
+            <button class="status-option completed" onclick="event.stopPropagation(); changeResumeStatus(${resume.id}, 'completed')">
+              <span class="status-icon"></span>
+              완료
+            </button>
+            <button class="status-option writing" onclick="event.stopPropagation(); changeResumeStatus(${resume.id}, 'writing')">
+              <span class="status-icon"></span>
+              작성중
+            </button>
+          </div>
+        </div>
 
         <div class="resume-dates">
           <span>작성일: ${formatDate(createdDate)}</span>
@@ -934,6 +1067,119 @@
       `;
 
     return card;
+  }
+
+  // 상태 드롭다운 표시
+  function showStatusDropdown(resumeId) {
+    // 모든 다른 드롭다운 닫기
+    document.querySelectorAll('.status-dropdown-menu').forEach(menu => {
+      menu.classList.remove('show');
+    });
+
+    // 해당 드롭다운 토글
+    const dropdown = document.getElementById(`statusDropdown-${resumeId}`);
+    dropdown.classList.add('show');
+  }
+
+  // 자소서 상태 변경
+  async function changeResumeStatus(resumeId, newStatus) {
+    const newStatusBackend = newStatus === 'completed' ? 'COMPLETED' : 'TEMP_SAVED';
+
+    try {
+      // 서버에 상태 변경 요청
+      const response = await fetch(`/api/resumes/${resumeId}`, {
+        method: 'PUT',
+        headers: getCSRFHeaders(),
+        body: JSON.stringify({
+          status: newStatusBackend
+        })
+      });
+
+      if (response.ok) {
+        // 로컬 데이터 업데이트
+        const resumeIndex = resumes.findIndex(r => r.id === resumeId);
+        if (resumeIndex !== -1) {
+          const oldStatus = getResumeStatus(resumes[resumeIndex]);
+
+          // 같은 상태를 선택한 경우 드롭다운만 닫기
+          if (oldStatus === newStatus) {
+            hideAllStatusDropdowns();
+            return;
+          }
+
+          resumes[resumeIndex].status = newStatusBackend;
+          // 수정일도 업데이트
+          resumes[resumeIndex].updatedAt = new Date().toISOString();
+          if (resumes[resumeIndex].updated_at) {
+            resumes[resumeIndex].updated_at = new Date().toISOString();
+          }
+        }
+
+        // 즉시 UI 업데이트
+        updateStats();
+        applyFilters();
+        renderResumes();
+
+        // 성공 토스트 메시지
+        const statusLabel = newStatus === 'completed' ? '완료' : '작성중';
+        const resumeTitle = resumes[resumeIndex]?.title || '자소서';
+        showStatusToast(`"${resumeTitle}" 상태가 "${statusLabel}"로 변경되었습니다.`);
+      } else {
+        throw new Error('상태 변경에 실패했습니다.');
+      }
+    } catch (error) {
+      console.error('Status change error:', error);
+
+      // API 실패시 로컬에서만 변경 (임시)
+      console.warn('API 오류로 인해 임시로 로컬에서만 상태를 변경합니다.');
+
+      const resumeIndex = resumes.findIndex(r => r.id === resumeId);
+      if (resumeIndex !== -1) {
+        const oldStatus = getResumeStatus(resumes[resumeIndex]);
+
+        // 같은 상태를 선택한 경우 드롭다운만 닫기
+        if (oldStatus === newStatus) {
+          hideAllStatusDropdowns();
+          return;
+        }
+
+        resumes[resumeIndex].status = newStatusBackend;
+        resumes[resumeIndex].updatedAt = new Date().toISOString();
+        if (resumes[resumeIndex].updated_at) {
+          resumes[resumeIndex].updated_at = new Date().toISOString();
+        }
+
+        // UI 업데이트
+        updateStats();
+        applyFilters();
+        renderResumes();
+
+        const statusLabel = newStatus === 'completed' ? '완료' : '작성중';
+        const resumeTitle = resumes[resumeIndex]?.title || '자소서';
+        showStatusToast(`"${resumeTitle}" 상태가 "${statusLabel}"로 변경되었습니다. (임시 변경)`);
+      }
+    }
+
+    // 드롭다운 닫기
+    hideAllStatusDropdowns();
+  }
+
+  // 모든 상태 드롭다운 숨기기
+  function hideAllStatusDropdowns() {
+    document.querySelectorAll('.status-dropdown-menu').forEach(menu => {
+      menu.classList.remove('show');
+    });
+  }
+
+  // 상태 변경 토스트 메시지 표시
+  function showStatusToast(message) {
+    const toast = document.getElementById('statusToast');
+    toast.textContent = message;
+    toast.classList.add('show');
+
+    setTimeout(() => {
+      toast.classList.remove('show');
+    }, 3000);
   }
 
   // 페이지네이션 렌더링
@@ -1029,7 +1275,7 @@
       });
 
       if (response.ok) {
-        alert('자소서가 삭제되었습니다.');
+        showStatusToast('자소서가 삭제되었습니다.');
         await loadResumes(); // 목록 새로고침
       } else {
         throw new Error('삭제에 실패했습니다.');
@@ -1043,7 +1289,7 @@
       updateStats();
       applyFilters();
       renderResumes();
-      alert('자소서가 삭제되었습니다. (임시 삭제)');
+      showStatusToast('자소서가 삭제되었습니다. (임시 삭제)');
     }
   }
 

--- a/src/main/resources/templates/resume/resume-result.html
+++ b/src/main/resources/templates/resume/resume-result.html
@@ -854,7 +854,7 @@
             method: 'POST',
             headers: getCSRFHeaders(),
             body: JSON.stringify({
-              sectionType: sectionType,
+              section_type: sectionType,
               content: textarea.value.trim()
             })
           });


### PR DESCRIPTION
## 📌 Summary
<!-- 이슈 번호
     이슈가 없다면 이 작업을 하게 된 이유 
     작업 내용 요약 -->
- resolved: #52 

<br>

## ✨ Description
<!-- 작업 내용 -->
- 자소서 목록 페이지를 구현했습니다.
- 자소서 진행 상태 (완료, 작성중)에 따라 필터링 가능하며, 작성일 기준 정렬할 수 있습니다.
- 회사명, 자소서 제목으로 검색할 수 있습니다.
- 한 페이지에는 10개의 자소서까지 확인할 수 있도록 구현했습니다.
 
<br>

- 사용자는 현재 상태를 클릭하여 작성중, 완료로 변경할 수 있습니다.
- 자소서 카드를 선택하면 자소서 작성 페이지로 넘어가 자소서 내용을 수정하거나 파일로 저장할 수 있습니다.
- 자소서 카드에서 hover 하면 자소서 정보 수정과 자소서 삭제를 할 수 있는 버튼이 나타납니다.
- 자소서 정보 수정은 resume-info 페이지로 넘어가 자소서 정보를 수정하고 AI 자소서를 새롭게 생성할 수 있습니다.
<br>

## 📸 Screenshot
<!-- img src "이부분에 gif파일 넣어주시면 됩니다" -->
|기능|스크린샷|
|:--:|:--:|
|GIF|<img src = "https://github.com/user-attachments/assets/656ab902-f427-438e-80d5-46495873f4e3" width ="700">|

<br>

## 🗒️ Review Point
<!-- 추가 필요한 사항이나 하고픈 말
     Reviewer 한테 요청하고 싶은 것들
     코드리뷰 요청하고 싶은 것들.. 등등 -->
```
내용을 입력해주세요
```
